### PR TITLE
fix file permissions for log files before attempting to upload

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -79,6 +79,12 @@ export async function install(
       const globber = await glob.create(patterns.join('\n'))
       const files = await globber.glob()
       if (files.length > 0) {
+        // If any of the files is not readable without root permissions, the upload will fail, so we need to
+        // fix the permissions first
+        for (const file of files) {
+          await exec(`sudo chmod 644 ${file}`)
+          await exec(`sudo chown $(whoami) ${file}`)
+        }
         const rootDirectory = '/var/log'
         const uploadResult = await artifact.uploadArtifact(
           artifactName,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -4,6 +4,7 @@ import * as glob from '@actions/glob'
 import {OSType, getOs, getRelease} from './platform'
 import {SemVer} from 'semver'
 import {exec} from '@actions/exec'
+import * as os from 'os'
 
 export async function install(
   executablePath: string,
@@ -78,12 +79,13 @@ export async function install(
       const patterns = ['/var/log/cuda-installer.log']
       const globber = await glob.create(patterns.join('\n'))
       const files = await globber.glob()
+      const username = os.userInfo().username
       if (files.length > 0) {
         // If any of the files is not readable without root permissions, the upload will fail, so we need to
         // fix the permissions first
         for (const file of files) {
           await exec(`sudo chmod 644 ${file}`)
-          await exec(`sudo chown \`whoami\` ${file}`)
+          await exec(`sudo chown ${username} ${file}`)
         }
         const rootDirectory = '/var/log'
         const uploadResult = await artifact.uploadArtifact(

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -83,7 +83,7 @@ export async function install(
         // fix the permissions first
         for (const file of files) {
           await exec(`sudo chmod 644 ${file}`)
-          await exec(`sudo chown $(whoami) ${file}`)
+          await exec(`sudo chown \`whoami\` ${file}`)
         }
         const rootDirectory = '/var/log'
         const uploadResult = await artifact.uploadArtifact(


### PR DESCRIPTION
When attempting to use `cuda-toolkit` with the [official GitHub Actions GPU-runners](https://github.blog/changelog/2024-07-08-github-actions-gpu-hosted-runners-are-now-generally-available/), the log file `'/var/log/cuda-installer.log'` ends up not having read permissions for the default user. Because the base nvidia image has strange permissions (presumably for security reasons), when the installation of the cuda toolkit is done with `sudo`, the file is created by root, and is inaccessible to others. Consequently, the `uploadArtifact` function for that log file will fail.

This PR resets the file permissions for log files before calling `uploadArtifact`. I have tested this on a private repo, and I can successfully run the action with the change in this PR.

Thank you @robandpdx for the initial investigation in [this comment](https://github.com/Jimver/cuda-toolkit/issues/207#issuecomment-2097289238).